### PR TITLE
Update runtime to 47

### DIFF
--- a/io.github.Pithos.json
+++ b/io.github.Pithos.json
@@ -1,7 +1,7 @@
 {
   "id": "io.github.Pithos",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "45",
+  "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
   "command": "pithos",
   "finish-args": [


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.