### PR TITLE
Update runtime to GNOME 50

### DIFF
--- a/io.github.Pithos.json
+++ b/io.github.Pithos.json
@@ -1,7 +1,7 @@
 {
   "id": "io.github.Pithos",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "50",
   "sdk": "org.gnome.Sdk",
   "command": "pithos",
   "finish-args": [


### PR DESCRIPTION
Update Pithos to the current GNOME 50 runtime and refresh the shared-modules revision for compatibility.

Supersedes #15, which targets GNOME 49.

Fixes #16.
Fixes #17.